### PR TITLE
Add DeepVAR multivariate time series option

### DIFF
--- a/autogluon/contrib/timeseries/__init__.py
+++ b/autogluon/contrib/timeseries/__init__.py
@@ -1,0 +1,3 @@
+"""Time series contrib module with DeepVAR support."""
+from .deepvar import DeepVARPredictor
+__all__ = ["DeepVARPredictor"]

--- a/autogluon/contrib/timeseries/deepvar.py
+++ b/autogluon/contrib/timeseries/deepvar.py
@@ -1,0 +1,60 @@
+"""Wrapper for training multivariate DeepVAR models using GluonTS."""
+from typing import Optional
+
+import pandas as pd
+from gluonts.dataset.pandas import PandasDataset
+from gluonts.model.deepvar import DeepVAREstimator
+from gluonts.mx import Trainer
+from gluonts.evaluation import MultivariateEvaluator
+
+
+class DeepVARPredictor:
+    """Simple interface for multivariate time series forecasting with DeepVAR."""
+
+    def __init__(self, prediction_length: int, freq: str = "D", epochs: int = 5):
+        self.prediction_length = prediction_length
+        self.freq = freq
+        self.epochs = epochs
+        self.estimator: Optional[DeepVAREstimator] = None
+        self.predictor = None
+
+    def fit(self, data: pd.DataFrame, target_columns):
+        """Train DeepVAR model.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            DataFrame containing a datetime index and target columns.
+        target_columns : list
+            Names of the columns to forecast.
+        """
+        dataset = PandasDataset(
+            data,
+            target=target_columns,
+            freq=self.freq,
+        )
+        trainer = Trainer(epochs=self.epochs)
+        self.estimator = DeepVAREstimator(
+            freq=self.freq,
+            prediction_length=self.prediction_length,
+            trainer=trainer,
+        )
+        self.predictor = self.estimator.train(dataset)
+        return self
+
+    def predict(self, data: pd.DataFrame, target_columns):
+        """Generate forecasts for the given data."""
+        if self.predictor is None:
+            raise RuntimeError("The model must be fit before calling predict().")
+        dataset = PandasDataset(data, target=target_columns, freq=self.freq)
+        forecasts = list(self.predictor.predict(dataset))
+        return forecasts
+
+    def evaluate(self, data: pd.DataFrame, target_columns):
+        """Evaluate the predictor on holdout data."""
+        if self.predictor is None:
+            raise RuntimeError("The model must be fit before calling evaluate().")
+        dataset = PandasDataset(data, target=target_columns, freq=self.freq)
+        evaluator = MultivariateEvaluator(target_agg_funcs={})
+        agg_metrics, _ = evaluator(self.predictor.predict(dataset), dataset)
+        return agg_metrics

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,12 @@ Tutorials
 
       How to make predictions based on text data.
 
+   .. card::
+      :title: Time Series Forecasting
+      :link: tutorials/time_series/index.html
+
+      Forecast multivariate time series with DeepVAR.
+
 
 Advanced Topics
 ~~~~~~~~~~~~~~~
@@ -89,6 +95,7 @@ Advanced Topics
    :hidden:
 
    tutorials/tabular_prediction/index
+   tutorials/time_series/index
    tutorials/image_classification/index
    tutorials/object_detection/index
    tutorials/text_classification/index

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -59,6 +59,17 @@ Tabular Prediction
       Using AutoGluon for Kaggle competitions with tabular data.
 
 
+Time Series Forecasting
+----------------------
+.. container:: cards
+
+   .. card::
+      :title: DeepVAR Quick Start
+      :link: time_series/deepvar.html
+
+      Train a multivariate DeepVAR model.
+
+
 Tuning Custom Models
 --------------------
 .. container:: cards
@@ -120,5 +131,6 @@ Neural Architecture Search
    object_detection/index
    text_classification/index
    tabular_prediction/index
+   time_series/index
    customize/index
    nas/index

--- a/docs/tutorials/time_series/deepvar.md
+++ b/docs/tutorials/time_series/deepvar.md
@@ -1,0 +1,22 @@
+# DeepVAR Quick Start
+
+This tutorial demonstrates how to train a multivariate time series forecasting model with the DeepVAR estimator from GluonTS using AutoGluon's contrib interface.
+
+```python
+import pandas as pd
+from autogluon.contrib.timeseries import DeepVARPredictor
+
+# prepare toy dataset
+index = pd.date_range("2020-01-01", periods=30, freq="D")
+data = pd.DataFrame({
+    "target1": range(30),
+    "target2": range(30, 60)
+}, index=index)
+
+predictor = DeepVARPredictor(prediction_length=5, freq="D", epochs=1)
+predictor.fit(data, target_columns=["target1", "target2"])
+
+forecasts = predictor.predict(data, target_columns=["target1", "target2"])
+for f in forecasts:
+    print(f.mean)
+```

--- a/docs/tutorials/time_series/index.rst
+++ b/docs/tutorials/time_series/index.rst
@@ -1,0 +1,10 @@
+Time Series Forecasting
+=======================
+
+.. container:: cards
+
+   .. card::
+      :title: DeepVAR Quick Start
+      :link: deepvar.html
+
+      Train a multivariate DeepVAR model with GluonTS backend.

--- a/examples/time_series/example_deepvar.py
+++ b/examples/time_series/example_deepvar.py
@@ -1,0 +1,17 @@
+"""Example of training a DeepVAR model using AutoGluon contrib module."""
+import pandas as pd
+from autogluon.contrib.timeseries import DeepVARPredictor
+
+# Example synthetic dataset with two target variables
+index = pd.date_range("2020-01-01", periods=30, freq="D")
+train_data = pd.DataFrame({
+    "target1": range(30),
+    "target2": range(30, 60)
+}, index=index)
+
+predictor = DeepVARPredictor(prediction_length=5, freq="D", epochs=1)
+predictor.fit(train_data, target_columns=["target1", "target2"])
+
+forecasts = predictor.predict(train_data, target_columns=["target1", "target2"])
+for f in forecasts:
+    print(f.mean)


### PR DESCRIPTION
## Summary
- add `DeepVARPredictor` wrapper in `autogluon.contrib.timeseries`
- create example usage for DeepVAR
- document new time series tutorial and update docs index

## Testing
- `python -m py_compile autogluon/contrib/timeseries/deepvar.py`
- `python -m py_compile autogluon/contrib/timeseries/__init__.py`
- `python -m py_compile examples/time_series/example_deepvar.py`
